### PR TITLE
Zonejs

### DIFF
--- a/src/root-config-dist.js
+++ b/src/root-config-dist.js
@@ -1,3 +1,6 @@
+// For angular
+import "zone.js";
+
 import { registerAllCoreApplications } from "./root-config-lib";
 import { start } from "single-spa";
 

--- a/src/root-config-dist.js
+++ b/src/root-config-dist.js
@@ -5,3 +5,35 @@ export * from "./root-config-lib";
 
 registerAllCoreApplications();
 start();
+
+// Workaround / waiting for https://github.com/systemjs/systemjs/issues/1939
+const moduleMap = {};
+
+export function getPublicPath(name) {
+  const path = moduleMap[name];
+  if (path) {
+    return path.slice(0, path.lastIndexOf("/") + 1);
+  } else {
+    throw Error("Cannot find public path for " + name);
+  }
+}
+
+const originalResolve = window.System.resolve;
+
+window.System.resolve = function(name) {
+  return originalResolve.apply(this, arguments).then(function(resolved) {
+    moduleMap[name] = resolved;
+    return resolved;
+  });
+};
+
+// We don't have a styleguide, so here's the very rudimentary version of one
+const css = `
+html {
+  background-color: #F4F5F8;
+}
+`;
+
+const styleEl = document.createElement("style");
+styleEl.textContent = css;
+document.head.appendChild(styleEl);

--- a/src/root-config-lib.js
+++ b/src/root-config-lib.js
@@ -4,7 +4,9 @@ const coreApplications = {
   "@openmrs/login": location =>
     location.pathname.startsWith("/openmrs/login") ||
     location.pathname.startsWith("/openmrs/spa/login"),
-  "@openmrs/devtools": () => localStorage.getItem("openmrs:devtools")
+  "@openmrs/devtools": () => localStorage.getItem("openmrs:devtools"),
+  "@hackathon/patient-dashboard": location =>
+    location.pathname.startsWith("/openmrs/spa/patient-dashboard")
 };
 
 export function registerAllCoreApplications() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,9 @@ module.exports = {
     },
     disableHostCheck: true
   },
-  externals: ["single-spa"],
+  externals: {
+    "single-spa": "single-spa",
+    "zone.js": "https://unpkg.com/zone.js@0.9.1/dist/zone.js"
+  },
   plugins: []
 };


### PR DESCRIPTION
Angular needs ZoneJS to work, but it's not in the core HTML file. This is a hack to make ZoneJS load in the root config before anything else is loaded so that Angular code doesn't have to load it itself.