### PR TITLE
Adding helper function for setting webpack public path.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  setupFiles: ["<rootDir>/src/setup-tests.js"]
+};

--- a/src/public-path-helpers.js
+++ b/src/public-path-helpers.js
@@ -1,0 +1,31 @@
+// See https://github.com/systemjs/systemjs/issues/1939 for what
+// we are doing here and why.
+
+const moduleMap = {};
+
+export function getModuleUrl(name) {
+  const url = moduleMap[name];
+  if (url) {
+    return url;
+  } else {
+    throw Error("Cannot find url for module " + name);
+  }
+}
+
+export function getPublicPath(name) {
+  const path = moduleMap[name];
+  if (path) {
+    return path.slice(0, path.lastIndexOf("/") + 1);
+  } else {
+    throw Error("Cannot find public path for " + name);
+  }
+}
+
+const originalResolve = window.System.resolve;
+
+window.System.resolve = function(name) {
+  return originalResolve.apply(this, arguments).then(function(resolved) {
+    moduleMap[name] = resolved;
+    return resolved;
+  });
+};

--- a/src/root-config-lib.js
+++ b/src/root-config-lib.js
@@ -45,3 +45,6 @@ export function registerCoreApplicationsExcept(names) {
 
   return registeredApps;
 }
+
+export { getPublicPath } from "./public-path-helpers";
+export { getModuleUrl } from "./public-path-helpers";

--- a/src/setup-tests.js
+++ b/src/setup-tests.js
@@ -1,0 +1,3 @@
+window.System = {
+  resolve: jest.fn()
+};


### PR DESCRIPTION
[Webpack public path](https://webpack.js.org/guides/public-path/) is the configuration that allows ESM modules to have multiple [code splits](https://webpack.js.org/guides/code-splitting/#root) within that module that are loaded from the correct URL. The code splits are not in-browser modules themselves, but just a bundling/webpack concept that SystemJS and import maps are not involved in. There are two ways to configure the public path -- build time and [on the fly](https://webpack.js.org/guides/public-path/#on-the-fly) (in the browser). It is nice for us to be able to do it on the fly because then we don't have to enforce any particular URL for where the bundles are going to be hosted in all of the various distributions.

In order to set the webpack public path on the fly, we need to ask SystemJS what the URL is for the module in the import map. Unfortunately, SystemJS does not have a way of doing that in a synchronous way. The [asynchronous way](https://github.com/systemjs/systemjs/blob/master/docs/api.md#systemresolveid--parenturl---promisestring) doesn't work for us because code splits often begin downloading immediately upon synchronous execution of the webpack bundle. See [discussion here](https://github.com/systemjs/systemjs/issues/1939) for more details on that. So what this PR does is put in place a workaround for that missing feature in SystemJS. If SystemJS ever has the functionality available to us, 