### PR TITLE
MF-116 Packmap gets wrong path for esm-error-handling and esm-root-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "@openmrs/esm-root-config",
   "version": "1.1.2",
   "description": "A javascript module for setting up and configuring your SPA ",
-  "main": "dist/openmrs-esm-root-config.lib.js",
+  "main": "dist/openmrs-esm-root-config.defaults.js",
   "scripts": {
     "clean": "rimraf dist",
     "start": "webpack-dev-server",
     "test": "jest",
     "lint": "eslint src",
+    "prettier": "prettier",
     "build": "npm run clean && webpack --mode production && webpack --entry ./src/openmrs-esm-root-config.lib.js --output-filename openmrs-esm-root-config.lib.js  --output-library-target commonjs",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-116

Changes the package main from the .lib.js to .defaults.js.