### PR TITLE
Add browser language detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5258,6 +5258,15 @@
         "@babel/runtime": "^7.3.1"
       }
     },
+    "i18next-browser-languagedetector": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-4.1.1.tgz",
+      "integrity": "sha512-akv0zurR/2KU7s1qaWkirY9FEEOT1TNsQaezEg8+1BLLQre7vylqb7tYoUgYqP/0/BEzXJgnoQnj+sh5xYFMhg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5"
+      }
+    },
     "i18next-icu": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/i18next-icu/-/i18next-icu-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-config-prettier": "^6.3.0",
     "eslint-plugin-prettier": "^3.1.0",
     "husky": "^3.0.5",
+    "i18next-browser-languagedetector": "^4.1.1",
     "i18next-icu": "^1.1.2",
     "i18next-xhr-backend": "^3.2.2",
     "jest": "^24.9.0",

--- a/src/i18next/init-i18next.js
+++ b/src/i18next/init-i18next.js
@@ -4,6 +4,8 @@ import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
 import ICU from "i18next-icu";
 
+window.i18next = i18n.default || i18n;
+
 export const translationsPromise = (i18n.default || i18n)
   .use(LanguageDetector)
   .use(i18nextXhrBackend)
@@ -45,6 +47,9 @@ export const translationsPromise = (i18n.default || i18n)
             });
         }
       }
+    },
+    detection: {
+      order: ["querystring", "htmlTag", "localStorage", "navigator"]
     },
     fallbackLng: "en"
   });

--- a/src/i18next/init-i18next.js
+++ b/src/i18next/init-i18next.js
@@ -1,9 +1,11 @@
 import i18n from "i18next";
 import i18nextXhrBackend from "i18next-xhr-backend";
+import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
 import ICU from "i18next-icu";
 
 export const translationsPromise = (i18n.default || i18n)
+  .use(LanguageDetector)
   .use(i18nextXhrBackend)
   .use(initReactI18next)
   .use(ICU)
@@ -44,7 +46,6 @@ export const translationsPromise = (i18n.default || i18n)
         }
       }
     },
-    lng: "en",
     fallbackLng: "en"
   });
 


### PR DESCRIPTION
This allows i18next to detect the user's language from any of the sources listed in the [i18next-browser-languageDetector README](https://github.com/i18next/i18next-browser-languageDetector). The important one for us is the navigator language.

This does not detect the language preference set in OpenMRS. That will have to come either 1. from the session object (which poses another problem for the login page, and would cause a double-render, where the first render is in English), or 2. embedded in the SPA index.html. I am leaning toward the latter approach.